### PR TITLE
Add getter and setter for the "Averaging and Sampling Configuration" register

### DIFF
--- a/adafruit_cap1188/cap1188.py
+++ b/adafruit_cap1188/cap1188.py
@@ -82,6 +82,7 @@ _AVG = (1, 2, 4, 8, 16, 32, 64, 128)
 _SAMP_TIME = ("320us", "640us", "1.28ms", "2.56ms")
 _CYCLE_TIME = ("35ms", "70ms", "105ms", "140ms")
 
+
 class CAP1188_Channel:
     # pylint: disable=protected-access
     """Helper class to represent a touch channel on the CAP1188. Not meant to


### PR DESCRIPTION
Fixes issue #16 

The methods provide (/ accept) a triple containing the three
parameters required to fully specify the register: avg, samp_time
and cycle_time.
This allows the user to tweak the responsiveness of the CAP1188.