### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_cap1188/cap1188.py
+++ b/adafruit_cap1188/cap1188.py
@@ -47,7 +47,6 @@ from micropython import const
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CAP1188.git"
 
-# pylint: disable=bad-whitespace
 _CAP1188_MID = const(0x5D)
 _CAP1188_PID = const(0x50)
 _CAP1188_MAIN_CONTROL = const(0x00)
@@ -74,7 +73,6 @@ _CAP1188_LED_LINKING = const(0x72)
 _CAP1188_PRODUCT_ID = const(0xFD)
 _CAP1188_MANU_ID = const(0xFE)
 _CAP1188_REVISION = const(0xFF)
-# pylint: enable=bad-whitespace
 
 _SENSITIVITY = (128, 64, 32, 16, 8, 4, 2, 1)
 

--- a/adafruit_cap1188/i2c.py
+++ b/adafruit_cap1188/i2c.py
@@ -49,9 +49,7 @@ from adafruit_cap1188.cap1188 import CAP1188
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CAP1188.git"
 
-# pylint: disable=bad-whitespace
 _CAP1188_DEFAULT_ADDRESS = const(0x29)
-# pylint: enable=bad-whitespace
 
 
 class CAP1188_I2C(CAP1188):

--- a/adafruit_cap1188/spi.py
+++ b/adafruit_cap1188/spi.py
@@ -49,11 +49,9 @@ from adafruit_cap1188.cap1188 import CAP1188
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_CAP1188.git"
 
-# pylint: disable=bad-whitespace
 _CAP1188_SPI_SET_ADDR = const(0x7D)
 _CAP1188_SPI_WRITE_DATA = const(0x7E)
 _CAP1188_SPI_READ_DATA = const(0x7F)
-# pylint: enable=bad-whitespace
 
 
 class CAP1188_SPI(CAP1188):


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.